### PR TITLE
fix(litellm): swiss-ai/-prefixed model id for CSCS Apertus deployments

### DIFF
--- a/charts/web_services/charts/litellm/values.yaml
+++ b/charts/web_services/charts/litellm/values.yaml
@@ -202,7 +202,7 @@ config:
     # Apertus 8B model via CSCS endpoint
     - model_name: swiss-ai/apertus-8b-instruct
       litellm_params:
-        model: openai/Apertus-8B-Instruct-2509
+        model: openai/swiss-ai/Apertus-8B-Instruct-2509
         api_base: https://llm-proxy.svc.cscs.ch/v1
         api_key: "os.environ/VLLM_API_KEY_CSCS"
         supports_vision: true  
@@ -230,7 +230,7 @@ config:
     # Apertus 70B model via CSCS endpoint
     - model_name: swiss-ai/apertus-70b-instruct
       litellm_params:
-        model: openai/Apertus-70B-Instruct-2509
+        model: openai/swiss-ai/Apertus-70B-Instruct-2509
         api_base: https://llm-proxy.svc.cscs.ch/v1
         api_key: "os.environ/VLLM_API_KEY_CSCS"
         supports_vision: true  


### PR DESCRIPTION
## What

Prefix the CSCS Apertus deployments' `model` id with `swiss-ai/`:

- `openai/Apertus-70B-Instruct-2509` -> `openai/swiss-ai/Apertus-70B-Instruct-2509`
- `openai/Apertus-8B-Instruct-2509` -> `openai/swiss-ai/Apertus-8B-Instruct-2509`

Both in the `swiss-ai/apertus-{70b,8b}-instruct` pools, `api_base: https://llm-proxy.svc.cscs.ch/v1`.

## Why

`/health` on the `swiss-ai/apertus-70b-instruct` group currently returns only 1 of 3 healthy. The CSCS deployment fails with:

```
litellm.BadRequestError: OpenAIException - /chat/completions:
Invalid model name passed in model=Apertus-70B-Instruct-2509.
Call `/v1/models` to view available models for your key.
```

This is config drift, not a CSCS outage: CSCS's `llm-proxy` gateway no longer recognizes the bare id. The healthy Infomaniak deployment in the same pool already uses the `swiss-ai/`-prefixed form, as does the intel 8B deployment. The prefixed id is also what SEA-LION's onboarding and the upstream `swiss-ai/Apertus-*-Instruct-2509` catalog use.

Because the failure is a 4xx, LiteLLM does not treat it as an availability error, so it does not fail over to the healthy peers. It surfaces to callers. Fixing the id restores CSCS to the pool.

## Verification

- 70B: verified end-to-end. The CSCS-side vLLM serves the 2509 weights, and the two healthy peers in the pool use the prefixed id.
- 8B: identical bug/pattern, included for consistency. Please confirm via `/health` after deploy. CSCS's 8B catalog has largely moved to Apertus 1.5, so if `swiss-ai/Apertus-8B-Instruct-2509` does not resolve on `llm-proxy`, that block may need a follow-up (repoint to a 1.5 id or drop).

No secrets touched. Both changed values are public model identifiers.

## Out of scope (separate follow-ups, not in this PR)

1. **Singapore key.** The `sea-lion-inference.com` Apertus deployment is healthy in config but fails with `api_key must be set` because `.Values.secrets.aisingaporeApiKey` is empty in the deploy. Populate that secret (verified working key exists). Not a repo change.
2. **Failover.** Consider adding `router_settings` (`fallbacks` / lower `cooldown_time` / `allowed_fails`) so a misconfigured or 4xx-erroring endpoint gets pulled from rotation instead of returning errors to callers.
3. **Deploy drift.** The running proxy shows CSCS `weight: 15` while `main` has `weight: 20`, so the live config is behind `main`. Confirm the deploy/sync path picks this up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
