### PR TITLE
fix(litellm): park broken CSCS lanes + wire Singapore's key (web.sh)

### DIFF
--- a/charts/web_services/charts/litellm/values.yaml
+++ b/charts/web_services/charts/litellm/values.yaml
@@ -206,7 +206,7 @@ config:
         api_base: https://llm-proxy.svc.cscs.ch/v1
         api_key: "os.environ/VLLM_API_KEY_CSCS"
         supports_vision: true  
-        weight: 20
+        weight: 0
         temperature: 0.8
         top_p: 0.9
         max_tokens: 16384
@@ -234,7 +234,7 @@ config:
         api_base: https://llm-proxy.svc.cscs.ch/v1
         api_key: "os.environ/VLLM_API_KEY_CSCS"
         supports_vision: true  
-        weight: 20
+        weight: 0
         temperature: 0.8
         top_p: 0.9
         max_tokens: 16384

--- a/web.sh
+++ b/web.sh
@@ -139,6 +139,7 @@ deploy_services() {
         --set litellm.secrets.deepinfraApiKey="$DEEPINFRA_API_KEY" \
         --set litellm.secrets.phoeniqsApiKey="$PHOENIQS_API_KEY" \
         --set litellm.secrets.bielikApiKey="$BIELIK_API_KEY" \
+        --set litellm.secrets.aisingaporeApiKey="$AISINGAPORE_API_KEY" \
         --set litellm.lago.enabled=true \
         --set lago.enabled=true \
         --set lago.global.databaseUrl="$LAGO_DATABASE_URL" \


### PR DESCRIPTION
## What

Two fixes that together restore the `swiss-ai/apertus-70b-instruct` pool to real multi-provider health:

1. **`values.yaml`** — park the broken CSCS lanes: CSCS 70B `weight: 20 → 0`, CSCS 8B `weight: 20 → 0`.
2. **`web.sh`** — add the missing `--set litellm.secrets.aisingaporeApiKey="$AISINGAPORE_API_KEY"` so a deploy actually wires Singapore's key.

Singapore's weight stays at `1` — with the `web.sh` fix, a deploy brings it up as a real second provider (no parking, no restore footgun).

## Why — CSCS (park it; the real fix is CSCS-side)

- 70B pool: CSCS `20` vs Infomaniak `1` + SEA-LION `1` → CSCS ≈ **91%** of routing weight. 8B pool: CSCS `20` vs intel `20` → **50%**.
- Verified via `/health` + `/health/test_connection` (reusing the deployment's own key): the bare id `Apertus-70B-Instruct-2509` (what our config sends) passes llm-proxy's allowlist, then fails **inside** llm-proxy with `400 Invalid model name`. Prefixed id → `team not allowed to access model` — so changing the id on our side is **not** the fix; our config is correct.
- Likely cause (not confirmed — can't see llm-proxy's internal config): the bare id no longer resolves to a live backend (`api.swissai.svc.cscs.ch` now serves 2509 only under suffixed names like `…-2509-WKYR`). Either way it's a **CSCS-side gateway fix**. Until then, `weight: 0` reclaims that traffic for healthy Infomaniak.

## Why — Singapore (a deploy-script bug, not a missing key)

`web.sh` lists `AISINGAPORE_API_KEY` in required_vars (so it's validated in `.env`), but the `helm upgrade` command never `--set`s `litellm.secrets.aisingaporeApiKey` — every other provider key has a `--set` line, this one was missing (jumps bielik → lago). So the k8s secret always rendered empty → Singapore `401 api_key must be set`, no matter how many deploys ran. The one-line fix wires it up.

## Net after deploy

70B pool → **Infomaniak + Singapore** both serving; CSCS parked. (8B → intel.)

## Restore note

- **CSCS:** leave at `0` until CSCS repairs their gateway; re-raise the weight only once `/health` shows it green.
- **Singapore:** no action needed — it's at `weight: 1` and the key is now wired, so it just comes up.

## Deploy notes

- `web.sh --deploy` is a full `helm upgrade` of the whole web-services stack (OpenWebUI + LiteLLM + Lago) — dry-run (`helm diff`) first; live config is already drifted from `main` (running CSCS weight `15` vs `20`), so a reconcile may apply more than these lines. The `.env` must include `AISINGAPORE_API_KEY`.
- No secrets in this diff.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
